### PR TITLE
fix(sdk): remove unneeded sdk ghcr credentials

### DIFF
--- a/components/kubeflow-pipeline/pipeline_components/image-builder/build.sh
+++ b/components/kubeflow-pipeline/pipeline_components/image-builder/build.sh
@@ -13,8 +13,7 @@ VERIFY_TLS="${4,}"
 REGISTRY=$(jq -r '.auths | keys[0]' /.docker/config.json | sed -e 's/https:\/\///')
 IMAGE_URL="${REGISTRY}/${IMAGE_TAG}"
 
-# TODO: remove 'upstream-docker' auth once our upstream images are public
-buildah bud --authfile /.upstream-docker/config.json --tag "$IMAGE_URL" --file Dockerfile "${BUILD_CONTEXT_PATH}"
+buildah bud --tag "$IMAGE_URL" --file Dockerfile "${BUILD_CONTEXT_PATH}"
 
 buildah push --authfile /.docker/config.json --tls-verify="$VERIFY_TLS" "$IMAGE_URL"
 

--- a/components/kubeflow-pipeline/python/fl_suite/pipelines/_build_image.py
+++ b/components/kubeflow-pipeline/python/fl_suite/pipelines/_build_image.py
@@ -14,7 +14,7 @@ from kfp.v2.dsl import ContainerOp
 from kubernetes import client as k8s_client
 
 from .._version import __version__
-from ._contants import INTERNAL_REGISTRY_SECRET, REGISTRY_SECRET
+from ._contants import INTERNAL_REGISTRY_SECRET
 
 
 def build_image(
@@ -65,18 +65,6 @@ def build_image(
     )
     build_image_op.add_volume_mount(
         k8s_client.V1VolumeMount(name="docker-config", mount_path="/.docker")
-    )
-    build_image_op.add_volume(
-        k8s_client.V1Volume(
-            name="upstream-docker-config",
-            secret=k8s_client.V1SecretVolumeSource(
-                secret_name=REGISTRY_SECRET,
-                items=[k8s_client.V1KeyToPath(key=".dockerconfigjson", path="config.json")],
-            ),
-        ),
-    )
-    build_image_op.add_volume_mount(
-        k8s_client.V1VolumeMount(name="upstream-docker-config", mount_path="/.upstream-docker")
     )
     build_image_op.container.add_resource_limit("smarter-devices/fuse", "1")
     build_image_op.container.add_resource_request("smarter-devices/fuse", "1")

--- a/components/kubeflow-pipeline/python/fl_suite/pipelines/_contants.py
+++ b/components/kubeflow-pipeline/python/fl_suite/pipelines/_contants.py
@@ -1,5 +1,2 @@
-# Kubernetes secret containing the credentials to pull from Katulu's image registry
-REGISTRY_SECRET = "regcred"
-
 # Kubernetes secret containing the credentials to push to the internal image registry
 INTERNAL_REGISTRY_SECRET = "internal-registry-credentials"

--- a/components/kubeflow-pipeline/python/fl_suite/pipelines/_pipelines.py
+++ b/components/kubeflow-pipeline/python/fl_suite/pipelines/_pipelines.py
@@ -4,11 +4,9 @@ from typing import Callable, Optional
 from kfp import Client, dsl
 from kfp.compiler import Compiler
 from kfp.dsl import ContainerOp, ExitHandler
-from kubernetes import client as k8s_client
 
 from .._version import __version__
 from ._build_image import build_image, static_image
-from ._contants import REGISTRY_SECRET
 from ._flower_infrastructure import cleanup_kubernetes_resources, setup_kubernetes_resources
 from ._flower_server import FLParameters, flwr_server
 from ._prepare_context import download_build_context
@@ -41,10 +39,6 @@ def _pipeline(
         min_fit_clients: int,
         min_eval_clients: int,
     ) -> None:
-        dsl.get_pipeline_conf().set_image_pull_secrets(
-            [k8s_client.V1ObjectReference(name=REGISTRY_SECRET)]
-        )
-
         with ExitHandler(cleanup_kubernetes_resources()):
             if fl_client is not None:
                 prepare_context_op = fl_client()

--- a/components/kubeflow-pipeline/python/pyproject.toml
+++ b/components/kubeflow-pipeline/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "fl_suite"
-version = "0.0.0+dev.8389153.1652445538"
+version = "0.0.0+dev.9f3ccf6"
 description = "Katulu FL Suite Tools"
 authors = ["Katulu <eng@katulu.io>"]
 homepage = "https://katulu.io"


### PR DESCRIPTION
Without this fix the standalone fl-suite deployment will not be able to run the fl-pipeline successfully due to the image builder not able to mount secrets.