### PR TITLE
Keep successful FL-Operator pods (jobs) and only restart on-failure

### DIFF
--- a/components/fl-operator/controllers/floperator_controller.go
+++ b/components/fl-operator/controllers/floperator_controller.go
@@ -151,29 +151,6 @@ func (r *FlOperatorReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		}, err
 	}
 
-	// Then cleanup the running clients that don't have
-	// a matching task in the response
-	for _, pod := range podsList.Items {
-		clientRunning := false
-
-		for _, task := range tasks {
-			if pod.Name == getPodName(task) {
-				clientRunning = true
-				break
-			}
-		}
-
-		if !clientRunning {
-			log.Info(fmt.Sprintf("Cleaning up pod: %s", pod.ObjectMeta.Name))
-
-			err = r.Delete(ctx, &pod)
-			if err != nil {
-				log.Error(err, "Couldn't delete pod resource")
-				continue
-			}
-		}
-	}
-
 	for _, task := range tasks {
 		log.Info(fmt.Sprintf("Found run ID: %s", task.ID))
 

--- a/components/fl-operator/pkg/resources/resources.go
+++ b/components/fl-operator/pkg/resources/resources.go
@@ -101,6 +101,9 @@ func NewPod(task *pb.OrchestratorMessage_TaskSpec, name types.NamespacedName, en
 					},
 				},
 			},
+			// RestartPolicy: OnFailure is preferred because it allows the pod to fail on transitive errors
+			// (e.g flower-client's envoyproxy not ready which causes it to crash)
+			RestartPolicy: "OnFailure",
 			Volumes: []corev1.Volume{
 				{
 					Name: envoyConfigVolumeKey,


### PR DESCRIPTION
Keeping the successful FL-Operator pods helps us to troubleshoot the fl-job executed on the edge.