### PR TITLE
fix(fl-orchestrator): remove extra service account token

### DIFF
--- a/components/fl-orchestrator/kustomize/kustomization.yaml
+++ b/components/fl-orchestrator/kustomize/kustomization.yaml
@@ -5,7 +5,6 @@ namespace: katulu-fl
 
 resources:
   - service-account.yaml
-  - secret.yaml
   - cluster-role-binding.yaml
   - deployment.yaml
   - service.yaml

--- a/components/fl-orchestrator/kustomize/secret.yaml
+++ b/components/fl-orchestrator/kustomize/secret.yaml
@@ -1,7 +1,0 @@
-apiVersion: v1
-kind: Secret
-metadata:
-  name: fl-orchestrator-token
-  annotations:
-    kubernetes.io/service-account.name: fl-orchestrator
-type: kubernetes.io/service-account-token


### PR DESCRIPTION
Keeping this extra token causes flakes when deploying the FL-Suite like:

apiVersion: "v1", kind: "Secret", namespace: "katulu-fl" name: "fl-orchestrator-token": get failed: secrets "fl-orchestrator-token" not found

Fortunately this token is not used, instead we are using the volume-kf-pipeline-token projected service account token.