### PR TITLE
docs(quickstart): add missing config in get_parameters

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -49,7 +49,7 @@ def mnist_client():
     model.compile("adam", "sparse_categorical_crossentropy", metrics=["accuracy"])
 
     class MNISTClient(fl.client.NumPyClient):
-        def get_parameters(self):
+        def get_parameters(self, config):
             return model.get_weights()
 
         def fit(self, parameters, config):


### PR DESCRIPTION
This fixes the:

```
TypeError: MNISTClient.get_parameters() got an unexpected keyword argument 'config'
```

seen when running the MNIST client.