### PR TITLE
fix(fl-operator): reconnect on reconcile to handle failures with envoy

### DIFF
--- a/components/fl-operator/main.go
+++ b/components/fl-operator/main.go
@@ -82,7 +82,6 @@ func main() {
 		Client:               mgr.GetClient(),
 		Scheme:               mgr.GetScheme(),
 		EnvoyproxyConfigFile: "./deployment/envoyproxy.yaml.tpl",
-		OrchestratorClient:   nil,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "FlOperator")
 		os.Exit(1)


### PR DESCRIPTION
In early cluster stage, envoy doesn't yet work as expected and needs a new gRPC connection once it does. This causes a problem with this controller as it caches the (falsy) connection once a first one is established. To fix this, we create a new connection every time the reconcile loop is run.